### PR TITLE
Restrict access of mailcow-postfix's container to the files needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ version: '2.1'
 services:
   postfix-mailcow:
     volumes:
-      - /opt/mailman:/opt/mailman
+      - /opt/mailman/core/var/data/:/opt/mailman/core/var/data/
     networks:
       - docker-mailman_mailman
 


### PR DESCRIPTION
The mailcow-postfix container only needs to access the files below $mailman_path/core/var/data and does not need to access the whole $mailman_path.

It's good practice to limit the scope of the files visible to the container to those needed. This is beneficial from a security perspective: Configuration secrets of mailman or i.e. the archives should not be accessible from within the mailcow-postfix container.